### PR TITLE
Add organization support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ inputs:
   github-token:
     description: 'GitHub Personal Access Token with package deletion permissions.'
     required: true
-  org:
+  github-org:
     description: 'If hosted in an organization, provide it here'
-    default: ""
+    default: ''
     required: true
 runs:
   using: "composite"
@@ -25,5 +25,5 @@ runs:
       run: pip install requests
       shell: bash
     - name: Delete image from ghcr.io
-      run: python ${{ github.action_path }}/docker-cleanup.py ${{ inputs.package-name }} ${{ inputs.tag }} ${{ inputs.github-token }} ${{ inputs.org }}
+      run: python ${{ github.action_path }}/docker-cleanup.py ${{ inputs.package-name }} ${{ inputs.tag }} ${{ inputs.github-token }} ${{ inputs.github-org }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   github-token:
     description: 'GitHub Personal Access Token with package deletion permissions.'
     required: true
+  org:
+    description: 'If hosted in an organization, provide it here'
+    default: ""
+    required: true
 runs:
   using: "composite"
   steps:
@@ -21,5 +25,5 @@ runs:
       run: pip install requests
       shell: bash
     - name: Delete image from ghcr.io
-      run: python ${{ github.action_path }}/docker-cleanup.py ${{ inputs.package-name }} ${{ inputs.tag }} ${{ inputs.github-token }}
+      run: python ${{ github.action_path }}/docker-cleanup.py ${{ inputs.package-name }} ${{ inputs.tag }} ${{ inputs.github-token }} ${{ inputs.org }}
       shell: bash

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -6,15 +6,21 @@
 import requests
 
 
-def get_package_versions(package_name, package_type):
-    print("get_package_versions", package_name, package_type)
-    # https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
+def get_package_versions(package_name, package_type, org):
+    print("get_package_versions", package_name, package_type, org)
     result = []
     done = False
     page = 1
 
+    if org:
+        # https://docs.github.com/en/rest/packages#list-packages-for-an-organization=
+        f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions"
+    else:
+        # https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
+        package_url = f"https://api.github.com/user/packages/{package_type}/{package_name}/versions"
+
     while not done:
-        response = session.get(f"https://api.github.com/user/packages/{package_type}/{package_name}/versions", params={"per_page" : 100, "page": page})
+        response = session.get(package_url, params={"per_page" : 100, "page": page})
         response.raise_for_status()
         json = response.json()
         result.extend(json)
@@ -24,46 +30,55 @@ def get_package_versions(package_name, package_type):
     return result
 
 
-def delete_package_version(package_name, package_type, id):
-    print("delete_package_version", package_name, package_type, id)
-
-    # https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
-    response = session.delete(f"https://api.github.com/user/packages/{package_type}/{package_name}/versions/{id}")
+def delete_package_version(package_name, package_type, id, org):
+    print("delete_package_version", package_name, package_type, id, org)
+    
+    if org:
+        # https://docs.github.com/en/rest/packages#delete-package-version-for-an-organization=
+        delete_url = f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions/{id}"
+    else:
+        # https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
+        delete_url = f"https://api.github.com/user/packages/{package_type}/{package_name}/versions/{id}"
+    response = session.delete(delete_url)
     response.raise_for_status()
 
 
-def get_tagged_container(package_name, tag):
-    print("get_tagged_container", package_name, tag)
-    packages = get_package_versions(package_name, "container")
+def get_tagged_container(package_name, tag, org):
+    print("get_tagged_container", package_name, tag, org)
+    packages = get_package_versions(package_name, "container", org)
     return [version for version in packages if tag in version["metadata"]["container"]["tags"]]
 
 
-def delete_tagged_container(package_name, tag):
-    print("delete_tagged_container", package_name, tag)
-    tags = get_tagged_container(package_name, tag)
+def delete_tagged_container(package_name, tag, org):
+    print("delete_tagged_container", package_name, tag, org)
+    tags = get_tagged_container(package_name, tag, org)
 
     if tags:
         for tag in tags:
-            delete_package_version(package_name, "container", tag["id"])
+            delete_package_version(package_name, "container", tag["id"], org)
     else:
-        raise Exception(f"No containers to delete: {package_name} {tag}")
+        raise Exception(f"No containers to delete: {package_name} {tag}")    
 
 
 ################################
 
 import sys
 
-if len(sys.argv) != 4:
-    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token>\nArgs: {sys.argv}")
+if len(sys.argv) < 4 or len(sys.argv) > 5:
+    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <org-optional>\nArgs: {sys.argv}")
 
 package_name = sys.argv[1]
 tag = sys.argv[2]
 token = sys.argv[3]
 
+org = None
+if len(sys.argv) == 5:
+    org = sys.argv[4]
+
 print("package_name = ", package_name)
 print("tag = ", tag)
+print("org = ", org)
 
 session = requests.Session()
 session.headers.update({"Authorization": f"token {token}", "Accept" : "application/vnd.github.v3+json"})
-delete_tagged_container(package_name, tag)
-
+delete_tagged_container(package_name, tag, org)

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -14,7 +14,7 @@ def get_package_versions(package_name, package_type, org):
 
     if org:
         # https://docs.github.com/en/rest/packages#list-packages-for-an-organization=
-        package_url = f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions"
+        package_url = f"https://api.github.com/orgs/{org}/packages/{package_type}/{package_name}/versions"
     else:
         # https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
         package_url = f"https://api.github.com/user/packages/{package_type}/{package_name}/versions"
@@ -35,7 +35,7 @@ def delete_package_version(package_name, package_type, id, org):
     
     if org:
         # https://docs.github.com/en/rest/packages#delete-package-version-for-an-organization=
-        delete_url = f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions/{id}"
+        delete_url = f"https://api.github.com/orgs/{org}/packages/{package_type}/{package_name}/versions/{id}"
     else:
         # https://docs.github.com/en/rest/reference/packages#delete-a-package-version-for-the-authenticated-user
         delete_url = f"https://api.github.com/user/packages/{package_type}/{package_name}/versions/{id}"

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -64,16 +64,13 @@ def delete_tagged_container(package_name, tag, org):
 
 import sys
 
-if len(sys.argv) < 4 or len(sys.argv) > 5:
+if len(sys.argv) != 5:
     raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <org-optional>\nArgs: {sys.argv}")
 
 package_name = sys.argv[1]
 tag = sys.argv[2]
 token = sys.argv[3]
-
-org = None
-if len(sys.argv) == 5:
-    org = sys.argv[4]
+org = sys.argv[4]
 
 print("package_name = ", package_name)
 print("tag = ", tag)

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -65,7 +65,7 @@ def delete_tagged_container(package_name, tag, org):
 import sys
 
 if len(sys.argv) != 5:
-    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <org-optional>\nArgs: {sys.argv}")
+    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <org (optional)>\nArgs: {sys.argv}")
 
 package_name = sys.argv[1]
 tag = sys.argv[2]

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -14,7 +14,7 @@ def get_package_versions(package_name, package_type, org):
 
     if org:
         # https://docs.github.com/en/rest/packages#list-packages-for-an-organization=
-        f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions"
+        package_url = f"https://api.github.com/user/packages/orgs/{org}/packages/{package_type}/{package_name}/versions"
     else:
         # https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-the-authenticated-user
         package_url = f"https://api.github.com/user/packages/{package_type}/{package_name}/versions"

--- a/docker-cleanup.py
+++ b/docker-cleanup.py
@@ -64,13 +64,16 @@ def delete_tagged_container(package_name, tag, org):
 
 import sys
 
-if len(sys.argv) != 5:
-    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <org (optional)>\nArgs: {sys.argv}")
+if len(sys.argv) < 4 or len(sys.argv) > 5:
+    raise SystemExit(f"Usage: docker-cleanup.py <package_name> <tag> <github_token> <github-org (optional)>\nArgs: {sys.argv}")
 
 package_name = sys.argv[1]
 tag = sys.argv[2]
 token = sys.argv[3]
-org = sys.argv[4]
+
+org = None
+if len(sys.argv) == 5:
+    org = sys.argv[4]
 
 print("package_name = ", package_name)
 print("tag = ", tag)


### PR DESCRIPTION
Adds an optional variable for org (default is left empty), and updates the code to change the endpoint it hits based on that variable.

An org-based use can be seen at https://github.com/tomtom-international/vault-assessment-prometheus-exporter/runs/7270040365?check_suite_focus=true and a personal run can be seen at https://github.com/eugene-davis/vault-assessment-prometheus-exporter/runs/7270095485?check_suite_focus=true